### PR TITLE
update to v2.10

### DIFF
--- a/edwin/baf/baldur_edwin_romance.baf
+++ b/edwin/baf/baldur_edwin_romance.baf
@@ -1,6 +1,9 @@
 IF
   Global("EdwinRomanceActive","GLOBAL",1)
   Global("EdwinRomanceOut","GLOBAL",0)
+  OR(2) //not if Edwin is Vampire
+    Global("EdwinVampire","GLOBAL",0)
+    GlobalGT("EdwinVampire","GLOBAL",5)
   !InPartyAllowDead("Edwin")
   !Dead("Edwin")
 THEN

--- a/edwin/baf/edwin.baf
+++ b/edwin/baf/edwin.baf
@@ -2,10 +2,11 @@ IF
   InParty(Myself)
   !See([ENEMY])
   CombatCounter(0)
+  Global("EdwinIgnoreRomances","GLOBAL",0)
   Global("EdwinRomanceActive","GLOBAL",2)
   OR(2)
-  Global("AnomenRomanceActive","GLOBAL",1)
-  Global("AnomenRomanceActive","GLOBAL",2)
+    Global("AnomenRomanceActive","GLOBAL",1)
+    Global("AnomenRomanceActive","GLOBAL",2)
 THEN
   RESPONSE #100
     SetGlobal("AnomenRomanceActive","GLOBAL",3)
@@ -15,6 +16,7 @@ IF
     InParty(Myself)
     CombatCounter(0)
     !See([ENEMY])
+    Global("EdwinIgnoreRomances","GLOBAL",0)
     Global("EdwinRomanceActive","GLOBAL",2)
     Global("RasaadRomanceActive","GLOBAL",1)
     Global("ED_DeactivateRomRasaad","LOCALS",0)
@@ -28,6 +30,7 @@ IF
     InParty(Myself)
     CombatCounter(0)
     !See([ENEMY])
+    Global("EdwinIgnoreRomances","GLOBAL",0)
     Global("EdwinRomanceActive","GLOBAL",2)
     Global("DornRomanceActive","GLOBAL",1)
     Global("ED_DeactivateRomDorn","LOCALS",0)
@@ -41,6 +44,7 @@ IF
     InParty(Myself)
     CombatCounter(0)
     !See([ENEMY])
+    Global("EdwinIgnoreRomances","GLOBAL",0)
     Global("EdwinRomanceActive","GLOBAL",2)
     Global("HexxatRomanceActive","GLOBAL",1)
     Global("ED_DeactivateRomHexxat","LOCALS",0)
@@ -57,6 +61,7 @@ IF
     InParty("Rasaad")
     CombatCounter(0)
     !See([ENEMY])
+    Global("EdwinIgnoreRomances","GLOBAL",0)
     Global("RasaadRomanceActive","GLOBAL",2)
     OR(2)
 	Global("EdwinRomanceActive","GLOBAL",1)
@@ -71,6 +76,7 @@ IF
     InParty("Dorn")
     CombatCounter(0)
     !See([ENEMY])
+    Global("EdwinIgnoreRomances","GLOBAL",0)
     Global("DornRomanceActive","GLOBAL",2)
     OR(2)
 	Global("EdwinRomanceActive","GLOBAL",1)
@@ -85,6 +91,7 @@ IF
     InParty("Hexxat")
     CombatCounter(0)
     !See([ENEMY])
+    Global("EdwinIgnoreRomances","GLOBAL",0)
     Global("HexxatRomanceActive","GLOBAL",2)
     OR(2)
 	Global("EdwinRomanceActive","GLOBAL",1)
@@ -100,27 +107,30 @@ IF
   InParty(Myself)
   !See([ENEMY])
   CombatCounter(0)
+  Global("EdwinIgnoreRomances","GLOBAL",0)
   OR(2)
-  Global("EdwinRomanceActive","GLOBAL",1)
-  Global("EdwinRomanceActive","GLOBAL",2)
+    Global("EdwinRomanceActive","GLOBAL",1)
+    Global("EdwinRomanceActive","GLOBAL",2)
   %ACTIVE_MOD_NPC_ROMANCE%
 THEN
   RESPONSE #100
     SetGlobal("EdwinRomanceActive","GLOBAL",3)
 END
 
+/*
 IF
   InParty(Myself)
   !See([ENEMY])
   CombatCounter(0)
   Global("EdwinRomanceActive","GLOBAL",2)
   OR(2)
-  Global("TsujathaRomanceActive","GLOBAL",1)
-  Global("TsujathaRomanceActive","GLOBAL",2)
+    Global("TsujathaRomanceActive","GLOBAL",1)
+    Global("TsujathaRomanceActive","GLOBAL",2)
 THEN
   RESPONSE #100
     SetGlobal("TsujathaRomanceActive","GLOBAL",3)
 END
+*/
 
 IF
   Global("EdwinMatch","GLOBAL",0)
@@ -266,7 +276,7 @@ IF
   !Global("Chapter","GLOBAL",%bg2_chapter_5%)
   !Global("Chapter","GLOBAL",%bg2_chapter_7%)
   !See([ENEMY])
-  !Range([NEUTRAL],10)
+//  !Range([NEUTRAL],10)
   OR(9)
   Global("EdwinLoveTalk","LOCALS",1)
   Global("EdwinLoveTalk","LOCALS",3)
@@ -414,6 +424,7 @@ THEN
     IncrementGlobal("EdwinLoveTalkCheck","GLOBAL",1)
 END
 
+/* 
 IF
   InParty(Myself)
   !See([ENEMY])
@@ -421,7 +432,7 @@ IF
   Global("EdwinMatch","GLOBAL",1)
   OR(4)
   Global("EdwinLoveTalk","LOCALS",10)
-  Global("EdwinLoveTalk","LOCALS",26)
+  Global("EdwinLoveTalk","LOCALS",32)
   Global("EdwinLoveTalk","LOCALS",36)
   Global("EdwinLoveTalk","LOCALS",22)
 THEN
@@ -430,6 +441,7 @@ THEN
     IncrementGlobal("EdwinLoveTalkCheck","GLOBAL",1)
     RealSetGlobalTimer("EdwinRomance","GLOBAL",1)
 END
+*/
 
 IF
   InParty(Myself)
@@ -515,7 +527,7 @@ IF
   CombatCounter(0)
   RealGlobalTimerExpired("EdwinRomance","GLOBAL")
   Global("EdwinMatch","GLOBAL",1)
-  OR(16)
+  OR(17)
   Global("EdwinLoveTalk","LOCALS",2)
   Global("EdwinLoveTalk","LOCALS",4)
   Global("EdwinLoveTalk","LOCALS",6)

--- a/edwin/baf/edwind.baf
+++ b/edwin/baf/edwind.baf
@@ -14,19 +14,19 @@ IF
   Global("EddieCantGetDrunk","GLOBAL",3)
 THEN
   RESPONSE #100
-    SetInterrupt(FALSE)
-    GiveItemCreate("EDPOTN",Myself,0,0,0)
-    MoveViewObject("Edwin",INSTANT)
-    Wait(2)
+//    SetInterrupt(FALSE)
+//    GiveItemCreate("EDPOTN",Myself,0,0,0)
+//    MoveViewObject("Edwin",INSTANT)
+//    Wait(2)
     SetGlobal("EdwinDrunk","GLOBAL",1)
-    UseItem("EDPOTN",Myself)
-    Wait(2)
+//    UseItem("EDPOTN",Myself)
+//    Wait(2)
     IncrementGlobal("EdwinLoveTalk","LOCALS",1)
     IncrementGlobal("EdwinLoveTalkCheck","GLOBAL",1)
     RealSetGlobalTimer("EdwinRomance","GLOBAL",2800)
     PlaySong(999990)
     SetInterrupt(TRUE)
-    Interact(Player1)
+    Interact(Myself)
 END
 
 IF
@@ -44,12 +44,12 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("EdwinKiss","GLOBAL",2)
-    MoveViewObject("Edwin",INSTANT)
+//    MoveViewObject("Edwin",INSTANT)
     IncrementGlobal("EdwinLoveTalk","LOCALS",1)
     IncrementGlobal("EdwinLoveTalkCheck","GLOBAL",1)
     RealSetGlobalTimer("EdwinRomance","GLOBAL",2800)
     PlaySong(999990)
-    Interact(Player1)
+    Interact(Myself)
 END
 
 IF
@@ -64,12 +64,12 @@ IF
   Global("EdwinLoveTalk","LOCALS",35)
 THEN
   RESPONSE #100
-    MoveViewObject("Edwin",INSTANT)
+//    MoveViewObject("Edwin",INSTANT)
     IncrementGlobal("EdwinLoveTalk","LOCALS",1)   
     IncrementGlobal("EdwinLoveTalkCheck","GLOBAL",1)
     RealSetGlobalTimer("EdwinRomance","GLOBAL",2800)
     PlaySong(999990)
-    Interact(Player1)
+    Interact(Myself)
 END
 
 IF
@@ -89,11 +89,11 @@ IF
   !Global("Chapter","GLOBAL",%bg2_chapter_7%)
 THEN
   RESPONSE #100
-    MoveViewObject("Edwin",INSTANT)
+//    MoveViewObject("Edwin",INSTANT)
     IncrementGlobal("EdwinLoveTalk","LOCALS",1)
     IncrementGlobal("EdwinLoveTalkCheck","GLOBAL",1)
     RealSetGlobalTimer("EdwinRomance","GLOBAL",2800)
     PlaySong(999991)
-    Interact(Player1)
+    Interact(Myself)
 END
 

--- a/edwin/dlg/eranomen.d
+++ b/edwin/dlg/eranomen.d
@@ -3,6 +3,166 @@
 //EDWIN ROMANCE MOD : ERANOMEN                         //
 //MODIFIED BANOMEN AND BEDWIN FOR EDWIN ROMANCE        //
 /////////////////////////////////////////////////////////
+
+
+I_C_T BANOMEN 106 ER_BANOMEN_106
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @0
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @1
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @2
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @15
+END
+
+I_C_T BANOMEN 173 ER_BANOMEN_173
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @3
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @4
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @5
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @6
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @7
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @16
+END
+
+I_C_T BANOMEN 311 ER_BANOMEN_311
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @8
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @9
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @10
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1)~ THEN
+      @11
+=     @17
+END
+
+
+INTERJECT BANOMEN 409 ER_BANOMEN_409
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1) Global("EdwinIgnoreRomances","GLOBAL",0)~ THEN
+      @12
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1) Global("EdwinIgnoreRomances","GLOBAL",0)~ THEN
+      @13
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1) Global("EdwinIgnoreRomances","GLOBAL",0)~ THEN
+      @22
+END
+   IF ~~ THEN REPLY @23 EXTERN BEDWIN ANO_EDWIN42
+   IF ~~ THEN REPLY @24 EXTERN BEDWIN ANO_EDWIN43
+   IF ~~ THEN REPLY @25 EXTERN BANOMEN ANO_EDWIN423
+   IF ~~ THEN REPLY @26 EXTERN BANOMEN ANO_EDWIN424
+
+APPEND BEDWIN
+IF ~~ THEN BEGIN ANO_EDWIN42
+   SAY @27
+   IF ~~ THEN DO ~SetGlobal("EdwinRomanceActive","GLOBAL",3)~ EXTERN BANOMEN ANO_EDWIN422
+END
+
+IF ~~ THEN BEGIN ANO_EDWIN43
+   SAY @28
+   IF ~~ DO ~SetGlobal("EdwinRomanceActive","GLOBAL",3) GivePartyAllEquipment() EscapeArea()~ EXTERN BANOMEN ANO_EDWIN422
+END
+END //APPEND
+
+APPEND BANOMEN
+
+IF ~~ THEN BEGIN ANO_EDWIN422
+    SAY @18
+    COPY_TRANS BANOMEN 409
+END
+
+IF ~~ THEN BEGIN ANO_EDWIN423
+    SAY @19
+    IF ~~ THEN DO ~SetGlobal("AnomenRomanceActive","GLOBAL",3)~ EXIT
+END
+
+IF ~~ THEN BEGIN ANO_EDWIN424
+    SAY @20
+    IF ~~ THEN DO ~SetGlobal("AnomenRomanceActive","GLOBAL",3) GivePartyAllEquipment() EscapeArea()~ EXIT
+END
+
+END //APPEND
+
+
+
+
+INTERJECT BANOMEN 341 ER_BANOMEN_341
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1) Global("EdwinIgnoreRomances","GLOBAL",0)~ THEN
+      @14
+== BANOMEN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1) Global("EdwinIgnoreRomances","GLOBAL",0)~ THEN
+      @13
+== BEDWIN IF ~InParty("Edwin") See("Edwin") !StateCheck("Edwin",CD_STATE_NOTVALID)
+Global("EdwinRomanceActive","GLOBAL",1) Global("EdwinIgnoreRomances","GLOBAL",0)~ THEN
+      @22
+END
+   IF ~~ THEN REPLY @23 EXTERN BEDWIN ANO_EDWIN52
+   IF ~~ THEN REPLY @24 EXTERN BEDWIN ANO_EDWIN53
+   IF ~~ THEN REPLY @25 EXTERN BANOMEN ANO_EDWIN523
+   IF ~~ THEN REPLY @29 EXTERN BANOMEN ANO_EDWIN524
+
+APPEND BEDWIN
+
+IF ~~ THEN BEGIN ANO_EDWIN52
+   SAY @30
+   IF ~~ THEN DO ~SetGlobal("EdwinRomanceActive","GLOBAL",3)~ EXTERN BANOMEN ANO_EDWIN522
+END
+
+IF ~~ THEN BEGIN ANO_EDWIN53
+   SAY @31
+   IF ~~ THEN DO ~SetGlobal("EdwinRomanceActive","GLOBAL",3) GivePartyAllEquipment() EscapeArea()~ EXTERN BANOMEN ANO_EDWIN522
+END
+
+END //APPEND
+
+APPEND BANOMEN
+
+IF ~~ THEN BEGIN ANO_EDWIN522
+    SAY @21
+    COPY_TRANS BANOMEN 341
+END
+
+IF ~~ THEN BEGIN ANO_EDWIN523
+    SAY @19
+    IF ~~ THEN DO ~SetGlobal("AnomenRomanceActive","GLOBAL",3)~ EXIT
+END
+
+IF ~~ THEN BEGIN ANO_EDWIN524
+    SAY @20
+    IF ~~ THEN DO ~SetGlobal("AnomenRomanceActive","GLOBAL",3) GivePartyAllEquipment() EscapeArea()~ EXIT
+END
+
+END //APPEND
+
+
+/*
+
+
+
+
 /*
 ADD_TRANS_TRIGGER  BANOMEN 106 ~!Global("EdwinRomanceActive","GLOBAL",1)~
 ADD_TRANS_TRIGGER  BANOMEN 173 ~!Global("EdwinRomanceActive","GLOBAL",1)~
@@ -141,8 +301,8 @@ APPEND BEDWIN
 
 IF ~~ THEN BEGIN ANO_EDWIN41
    SAY @22
-   IF ~~ THEN REPLY @23 GOTO ANO_EDWIN42
-   IF ~~ THEN REPLY @24 GOTO ANO_EDWIN43
+   IF ~~ THEN REPLY @23 EXTERN BEDWIN ANO_EDWIN52
+   IF ~~ THEN REPLY @24 EXTERN BEDWIN ANO_EDWIN53
    IF ~~ THEN REPLY @25 EXTERN BANOMEN ANO_EDWIN423
    IF ~~ THEN REPLY @26 EXTERN BANOMEN ANO_EDWIN424
 END
@@ -177,3 +337,4 @@ END
 
 END
 
+*/

--- a/edwin/dlg/erlovetalk2.d
+++ b/edwin/dlg/erlovetalk2.d
@@ -1074,7 +1074,7 @@ IF ~~ THEN BEGIN E160
 	EscapeArea()~ SOLVED_JOURNAL @471 EXIT
 END
 
-//Edwin LT 25
+//Edwin LT 22
 IF WEIGHT #-79 ~Global("BeginEdElDek","LOCALS",0) Global("EdwinMatch","GLOBAL",1) Global("EdwinLoveTalk","LOCALS",44)~ E161
   SAY @496
   ++ @497 DO ~IncrementGlobal("EdwinLoveTalk","LOCALS",1)

--- a/edwin/edwinromance-readme.html
+++ b/edwin/edwinromance-readme.html
@@ -316,7 +316,7 @@
         <p class="about">
           <a href="http://www.spellholdstudios.net/ie/edwin">Mod Website</a> &#8226;
           <a href="http://www.shsforums.net/forum/69-edwin-romance/">Mod Forum</a> &#8226;
-          Version: 2.0.9
+          Version: 2.1.0
         </p>
         <hr />
         <p class="menu">
@@ -397,6 +397,12 @@ party is currently in.</p>
 
           <h6>The Endings</h6>
           <p>There are three different ToB endings. One for the PC who stays with Edwin, and one for the PC who becomes a Goddess. The third and final is for non-romanced Edwin, since I personally don't care for the original one.</p>
+		  
+		  <h6>Multi-Romance Cheats</h6>
+          <p>Version 2.0.10 and higher provides the possibility to play Edwin Romance in Multi-Romance mode:
+		  Via Cheats, set the variable "EdwinIgnoreRomances" to "1" to enable Multi-Romance mode:</p>
+		  <p>CLUAConsole:SetGlobal("EdwinIgnoreRomances","GLOBAL",1)</p>
+		  <p>If set, Edwin Romance will ignore all other romances and will also ignored by other romances (as far as the checks are contained within the Edwin Romance Mod). This goes for the original romances as well as considered mod NPC romances. The cheat has to be set before any of the romances turn their status to committed.</p>
           <address>
             <span class="footer">Edwin Romance &gt; About</span> <a href="#top">BACK TO TOP</a>
           </address>
@@ -493,6 +499,17 @@ Anybody I have forgotten, please let me know and I will include you.</span><br /
         <a name="version" id="version"></a>
         <div class="content">
           <h2>Version history</h2>
+
+          <h6>Version 2.0.10:</h6>
+          <ul>
+            <li>Fixed a script bug that would lead to skipping of LT 13.</li>
+			<li>Fixed a bug that would lead to EdwinRomanceActive being set 3 if romance set to committed.</li>
+			<li>Inserted cheat variable Global("EdwinIgnoreRomances","GLOBAL",0): if set to "1", other romances will be ignored and other romances will ignore Edwin romance.</li>
+			<li>Triggering of LTs more stable and frequent: rest dialogues will be triggered by "Interact(Myself)" to make them trigger instantly without Edwin first having to move to the PC; removed the check of nearby NEUTRAL game characters as it tends to prevent dialogues to trigger for most city areas, removed the MoveViewObject from rest talks.</li>
+            <li>Removed the drinking of an actual potion before the "drunk" rest talk (as it might lead to an inventory item being dropped unnoticed).</li>			
+            <li>Interjections into Anomens' LTs recoded (using I_C_T for compatibility).</li>
+            <li>Renamed setup-edwinromance.ini to edwinromance.ini and added links.</li>
+          </ul>
 
           <h6>Version 2.0.9:</h6>
           <ul>

--- a/edwin/edwinromance.ini
+++ b/edwin/edwinromance.ini
@@ -14,23 +14,21 @@ Name = Edwin Romance
 Author = Laufey and others
 
 # Short description of the mod, main goals, features etc
-Description = Question: So, what's this all about, anyway?
-
-Answer: It is a Weidu mod for Baldur's Gate, Shadows of Amn, that allows the player to carry out a romantic relationship with Edwin Odesseiron, that insulting Thayvian wizard wearing red. It is also the culmination of a very long project for me, and one that would never have been finished without the help of many different people. For more information on that, see the Credits section. I had a lot of fun writing this mod - if it gives you, the player, even a fraction of that pleasure, I will be content.
+Description = Edwin Romance is a Weidu mod for Baldur's Gate, Shadows of Amn, that allows the player to carry out a romantic relationship with Edwin Odesseiron, that insulting Thayvian wizard wearing red. 
 
 An additional optional component for the romance is a new epilogue for romanced and redeemed Viconia, of a less tragic kind than the original one. Note that this will in no way affect the Edwin romance in itself, so if you prefer Viconia's original epilogue, simply bypass this component upon installation.
 
 The mod is directly compatible with all BGII games: BGII, BGT, BGII:EE, and EET.
 
 # Web address of mod Homepage
-Homepage = 
+Homepage = http://www.spellholdstudios.net/ie/edwin
 
 #  Web address of mod dedicated forum or forum thread 
-Forum = 
+Forum = http://www.shsforums.net/forum/69-edwin-romance/
 
 # if you use Github.com (preferred hosting site), simply use github.com/AccountOrOrgName/RepositoryName    
 # If you use other hosting sites, please check requirements and put direct download link  
-Download = 
+Download = https://github.com/SpellholdStudios/Edwin_Romance
 
 # Requirements for other hosting sites:
 # - forum attachments won't work because the download links will be changed every time when you update mod package

--- a/edwin/tra/english/eranomen.tra
+++ b/edwin/tra/english/eranomen.tra
@@ -19,7 +19,7 @@
 @16   = ~I thought you wanted me to be more purposeful? And now my lady, let us return to our so sadly interrupted conversation. I was wondering if I had told you how I became a priest?~
 @17   = ~I...I am sorry <CHARNAME>. As I said, my upcoming Test has me on edge these days.~
 @18   = ~Thank you, my lady. And now, as to this flower...~
-@19   = ~I am sorry too, my lady. For...for presuming to much. It seems I must withdraw from the field of battle then.~
+@19   = ~I am sorry too, my lady. For...for presuming too much. It seems I must withdraw from the field of battle then.~
 @20   = ~Nor, it seems, for the loyalty and devotion I would have given you along with it, <CHARNAME>. So be it then.~
 @21   = ~Thank you, my lady. And now, as to my conclusion on your own sweet self...~
 @22   = ~Meaning you, I suppose? <CHARNAME>, you should disabuse this armor-plated monkey of the delusion that you find him anything other than a source of comic relief.~

--- a/setup-edwinromance.tp2
+++ b/setup-edwinromance.tp2
@@ -8,7 +8,7 @@ BACKUP ~edwin/backup~
 SUPPORT ~http://www.shsforums.net/forum/69-edwin-romance/~
 
 README ~edwin/edwinromance-readme.html~
-VERSION ~v2.0.9~
+VERSION ~v2.1.0~ //
 
 AUTO_TRA ~edwin/tra/%s~
 
@@ -162,14 +162,13 @@ DESIGNATED 0
 
 /* I externalized this so new mod romances can be added more easily */
 OUTER_SPRINT ~ACTIVE_MOD_NPC_ROMANCE~ 
-~OR(17)
+~OR(16)
 	Global("E3FadeRomanceActive","GLOBAL",2)	//Fade
 	Global("rh#AdrianRomanceActive","GLOBAL",2)	//Adrian
 	Global("C#AjantisRomanceActive","GLOBAL",2) 	//Ajantis BGII
 	Global("ADAngelRomanceActive","GLOBAL",2)	//Angelo
 	Global("c-AranRomanceActive","GLOBAL",2) 	//Aran Whitehand
 	Global("ChloeRomanceActiveCR","GLOBAL",2) 	//Chloe
-	Global("EdwinRomanceActive","GLOBAL",2) 	//Edwin Romance
 	Global("B!GavRA","GLOBAL",2) 			//Gavin BGII
 	Global("ImoenRomanceActive","GLOBAL",2) 	//Imoen Romance
 	Global("J#KelseyRomanceActive","GLOBAL",2) 	//Kelsey
@@ -188,7 +187,6 @@ OUTER_SPRINT ~NO_ACTIVE_MOD_NPC_ROMANCE~
 	!Global("ADAngelRomanceActive","GLOBAL",2)	//Angelo
 	!Global("c-AranRomanceActive","GLOBAL",2) 	//Aran Whitehand
 	!Global("ChloeRomanceActiveCR","GLOBAL",2) 	//Chloe
-	!Global("EdwinRomanceActive","GLOBAL",2) 	//Edwin Romance
 	!Global("B!GavRA","GLOBAL",2) 			//Gavin BGII
 	!Global("ImoenRomanceActive","GLOBAL",2) 	//Imoen Romance
 	!Global("J#KelseyRomanceActive","GLOBAL",2) 	//Kelsey


### PR DESCRIPTION
    Fixed a script bug that would lead to skipping of LT 13.
    Fixed a bug that would lead to EdwinRomanceActive being set 3 if romance set to committed.
    Inserted cheat variable Global("EdwinIgnoreRomances","GLOBAL",0): if set to "1", other romances will be ignored and other romances will ignore Edwin romance.
    Triggering of LTs more stable and frequent: rest dialogues will be triggered by "Interact(Myself)" to make them trigger instantly without Edwin first having to move to the PC; removed the check of nearby NEUTRAL game characters as it tends to prevent dialogues to trigger for most city areas, removed the MoveViewObject from rest talks.
    Removed the drinking of an actual potion before the "drunk" rest talk (as it might lead to an inventory item being dropped unnoticed).
    Interjections into Anomens' LTs recoded (using I_C_T for compatibility).
    Renamed setup-edwinromance.ini to edwinromance.ini and added links.